### PR TITLE
Sprint 4: Delete short URLs

### DIFF
--- a/cmd/shortener/server.go
+++ b/cmd/shortener/server.go
@@ -19,7 +19,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	r := handlers.NewShortenerRouter(repo, cfg.BaseURL)
+	r := handlers.NewShortenerRouter(repo, cfg.BaseURL, 10)
 	err = http.ListenAndServe(cfg.Addr, r)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/handlers/delete.go
+++ b/internal/handlers/delete.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"encoding/json"
+	log "github.com/sirupsen/logrus"
+	"go-url-shortener/internal/middlewares"
+	"go-url-shortener/internal/storage"
+	"net/http"
+)
+
+func DeleteShortURLs(db storage.Storager) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, err := middlewares.GetUserID(r)
+		if err != nil {
+			log.Error(err)
+			http.Error(w, "couldn't identify the user", http.StatusInternalServerError)
+			return
+		}
+
+		var req []string
+		if err = json.NewDecoder(r.Body).Decode(&req); err != nil {
+			log.Error(err)
+			http.Error(w, "Couldn't delete the records", http.StatusInternalServerError)
+			return
+		}
+
+		batch := make([]storage.ShortURL, len(req))
+		for i, v := range req {
+			batch[i] = storage.ShortURL{
+				ID:  v,
+				UID: userID,
+			}
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(""))
+	}
+}

--- a/internal/handlers/delete.go
+++ b/internal/handlers/delete.go
@@ -32,7 +32,14 @@ func DeleteShortURLs(db storage.Storager) func(w http.ResponseWriter, r *http.Re
 			}
 		}
 
+		err = db.Delete(batch)
+		if err != nil {
+			log.Error(err)
+			http.Error(w, "Something went wrong.", http.StatusInternalServerError)
+			return
+		}
+
 		w.WriteHeader(http.StatusAccepted)
-		w.Write([]byte(""))
+		w.Write([]byte("Success"))
 	}
 }

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func NewShortenerRouter(db storage.Storager, baseURL string) *chi.Mux {
+func NewShortenerRouter(db storage.Storager, baseURL string, poolSize int) *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(middlewares.Authorize, middlewares.Compress, middlewares.Decompress)
 
@@ -26,7 +26,7 @@ func NewShortenerRouter(db storage.Storager, baseURL string) *chi.Mux {
 			r.Route("/user", func(r chi.Router) {
 				r.Route("/urls", func(r chi.Router) {
 					r.Get("/", UserURLsHandler(db, baseURL))
-					r.Delete("/", DeleteShortURLs(db))
+					r.Delete("/", DeleteShortURLs(db, poolSize))
 				})
 			})
 		})

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -24,7 +24,10 @@ func NewShortenerRouter(db storage.Storager, baseURL string) *chi.Mux {
 			})
 
 			r.Route("/user", func(r chi.Router) {
-				r.Get("/urls", UserURLsHandler(db, baseURL))
+				r.Route("/urls", func(r chi.Router) {
+					r.Get("/", UserURLsHandler(db, baseURL))
+					r.Delete("/", DeleteShortURLs(db))
+				})
 			})
 		})
 

--- a/internal/handlers/web_get.go
+++ b/internal/handlers/web_get.go
@@ -19,6 +19,7 @@ func GetFullURL(db storage.Storager) func(w http.ResponseWriter, r *http.Request
 
 		if sURL.Deleted {
 			http.Error(w, "The requested URL is not available.", http.StatusGone)
+			return
 		}
 
 		http.Redirect(w, r, sURL.URL, http.StatusTemporaryRedirect)

--- a/internal/handlers/web_get.go
+++ b/internal/handlers/web_get.go
@@ -10,13 +10,17 @@ import (
 func GetFullURL(db storage.Storager) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		url, err := db.Get(id)
+		sURL, err := db.Get(id)
 		if err != nil {
 			log.Error(err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		if sURL.Deleted {
+			http.Error(w, "The requested URL is not available.", http.StatusGone)
+		}
+
+		http.Redirect(w, r, sURL.URL, http.StatusTemporaryRedirect)
 	}
 }

--- a/internal/storage/file.go
+++ b/internal/storage/file.go
@@ -37,7 +37,7 @@ func (f FileRepo) Add(batch []ShortURL) ([]ShortURL, error) {
 
 	w := bufio.NewWriter(file)
 	for _, sURL := range batch {
-		_, err = w.WriteString(sURL.ID + " : " + sURL.URL + " : " + sURL.UID + "\n")
+		_, err = w.WriteString(sURL.ID + " : " + sURL.URL + " : " + sURL.UID + "false\n")
 		if err != nil {
 			return nil, err
 		}
@@ -52,10 +52,10 @@ func (f FileRepo) Add(batch []ShortURL) ([]ShortURL, error) {
 	return res, file.Close()
 }
 
-func (f FileRepo) Get(id string) (string, error) {
+func (f FileRepo) Get(id string) (ShortURL, error) {
 	file, err := os.OpenFile(f.filename, os.O_RDONLY|os.O_CREATE, 0777)
 	if err != nil {
-		return "", err
+		return ShortURL{}, err
 	}
 	defer file.Close()
 
@@ -64,20 +64,25 @@ func (f FileRepo) Get(id string) (string, error) {
 		text := scanner.Text()
 		data := strings.Split(text, " : ")
 
-		if len(data) < 3 {
-			return "", errors.New("malformed file: " + file.Name())
+		if !isEntryValid(data) {
+			return ShortURL{}, errors.New("malformed file: " + file.Name())
 		}
 
 		if data[0] == id {
-			return data[1], nil
+			return ShortURL{
+				ID:      data[0],
+				URL:     data[1],
+				UID:     data[2],
+				Deleted: data[3] == "true",
+			}, nil
 		}
 	}
 
 	if scanner.Err() != nil {
-		return "", scanner.Err()
+		return ShortURL{}, scanner.Err()
 	}
 
-	return "", errors.New("no matching URL found: " + id)
+	return ShortURL{}, errors.New("no matching URL found: " + id)
 }
 
 func (f FileRepo) GetAll(userID string) ([]ShortURL, error) {
@@ -95,15 +100,16 @@ func (f FileRepo) GetAll(userID string) ([]ShortURL, error) {
 	for ; scanner.Scan(); counter++ {
 		data := strings.Split(scanner.Text(), " : ")
 
-		if len(data) < 3 {
+		if !isEntryValid(data) {
 			return nil, errors.New("malformed file: " + file.Name())
 		}
 
 		if data[2] == userID {
 			urls = append(urls, ShortURL{
-				ID:  data[0],
-				URL: data[1],
-				UID: userID,
+				ID:      data[0],
+				URL:     data[1],
+				UID:     userID,
+				Deleted: data[3] == "true",
 			})
 		}
 	}
@@ -136,7 +142,7 @@ func (f FileRepo) Has(id string) (bool, error) {
 
 	for ; scanner.Scan(); counter++ {
 		data := strings.Split(scanner.Text(), " : ")
-		if len(data) < 3 {
+		if !isEntryValid(data) {
 			return false, nil
 		}
 
@@ -157,4 +163,54 @@ func (f FileRepo) Clear() {
 func (f FileRepo) Ping() bool {
 	_, err := os.Stat(f.filename)
 	return err == nil
+}
+
+func (f FileRepo) Delete(batch []ShortURL) error {
+	file, err := os.OpenFile(f.filename, os.O_RDONLY, 0777)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	IDtoSURL := make(map[string]ShortURL, len(batch))
+	for _, v := range batch {
+		IDtoSURL[v.ID] = v
+	}
+
+	restore := make([]ShortURL, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		data := strings.Split(scanner.Text(), " : ")
+
+		if !isEntryValid(data) {
+			return errors.New("malformed file: " + file.Name())
+		}
+
+		if sURL := IDtoSURL[data[0]]; sURL.UID == "" {
+			restore = append(restore, ShortURL{
+				ID:      data[0],
+				URL:     data[1],
+				UID:     data[2],
+				Deleted: sURL.UID == data[2],
+			})
+		}
+	}
+
+	if scanner.Err() != nil {
+		return scanner.Err()
+	}
+
+	f.Clear()
+	if _, err = f.Add(restore); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isEntryValid(entry []string) bool {
+	return len(entry) == 4
 }

--- a/internal/storage/file.go
+++ b/internal/storage/file.go
@@ -37,7 +37,7 @@ func (f FileRepo) Add(batch []ShortURL) ([]ShortURL, error) {
 
 	w := bufio.NewWriter(file)
 	for _, sURL := range batch {
-		_, err = w.WriteString(sURL.ID + " : " + sURL.URL + " : " + sURL.UID + "false\n")
+		_, err = w.WriteString(sURL.ID + " : " + sURL.URL + " : " + sURL.UID + " : false\n")
 		if err != nil {
 			return nil, err
 		}
@@ -143,6 +143,7 @@ func (f FileRepo) Has(id string) (bool, error) {
 	for ; scanner.Scan(); counter++ {
 		data := strings.Split(scanner.Text(), " : ")
 		if !isEntryValid(data) {
+			log.Error(data)
 			return false, nil
 		}
 

--- a/internal/storage/file_test.go
+++ b/internal/storage/file_test.go
@@ -65,13 +65,13 @@ func TestFileRepo_Get(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = repo.Add([]ShortURL{{ID: "googl", URL: "https://google.com"}})
+			_, err = repo.Add([]ShortURL{{ID: "googl", URL: "https://google.com", UID: UserID}})
 			if err != nil {
 				t.Fatal(err)
 			}
-			url, err := repo.Get(tt.id)
+			sURL, err := repo.Get(tt.id)
 			assert.Equal(t, tt.wantErr, err != nil)
-			assert.Equal(t, tt.want, url)
+			assert.Equal(t, tt.want, sURL.URL)
 			repo.Clear()
 		})
 	}
@@ -86,7 +86,7 @@ func TestFileRepo_Has(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = repo.Add([]ShortURL{{ID: "googl", URL: "https://google.com"}})
+			_, err = repo.Add([]ShortURL{{ID: "googl", URL: "https://google.com", UID: UserID}})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/storage/memo.go
+++ b/internal/storage/memo.go
@@ -31,12 +31,12 @@ func (m *MemoRepo) Has(id string) (bool, error) {
 	return false, nil
 }
 
-func (m *MemoRepo) Get(id string) (string, error) {
+func (m *MemoRepo) Get(id string) (ShortURL, error) {
 	if sURL, ok := m.db.Load(id); ok {
-		return sURL.(ShortURL).URL, nil
+		return sURL.(ShortURL), nil
 	}
 
-	return "", errors.New("no matching URL found")
+	return ShortURL{}, errors.New("no matching URL found")
 }
 
 func (m *MemoRepo) GetAll(userID string) ([]ShortURL, error) {
@@ -62,4 +62,19 @@ func (m *MemoRepo) Clear() {
 
 func (m *MemoRepo) Ping() bool {
 	return true
+}
+
+func (m *MemoRepo) Delete(batch []ShortURL) error {
+	for _, sURL := range batch {
+		stored, ok := m.db.Load(sURL.ID)
+		if !ok || stored.(ShortURL).UID != sURL.UID {
+			continue
+		}
+
+		newURL := stored.(ShortURL)
+		newURL.Deleted = true
+		m.db.Store(sURL.ID, newURL)
+	}
+
+	return nil
 }

--- a/internal/storage/memo_test.go
+++ b/internal/storage/memo_test.go
@@ -48,9 +48,9 @@ func TestMemoRepo_Get(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			url, err := r.Get(tt.id)
+			sURL, err := r.Get(tt.id)
 			assert.Equal(t, tt.wantErr, err != nil)
-			assert.Equal(t, tt.want, url)
+			assert.Equal(t, tt.want, sURL.URL)
 		})
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,16 +1,18 @@
 package storage
 
 type ShortURL struct {
-	ID  string
-	URL string
-	UID string
+	ID      string
+	URL     string
+	UID     string
+	Deleted bool
 }
 
 type Storager interface {
 	Add(batch []ShortURL) ([]ShortURL, error)
-	Has(id string) (bool, error)
-	Get(id string) (string, error)
-	GetAll(userID string) ([]ShortURL, error)
 	Clear()
+	Delete(batch []ShortURL) error
+	Get(id string) (ShortURL, error)
+	GetAll(userID string) ([]ShortURL, error)
+	Has(id string) (bool, error)
 	Ping() bool
 }


### PR DESCRIPTION
Sprint 4: Delete short URLs

**Changes**:
* Expand the model with delete flag.
* Refactor existing repo implementations to work with soft-deleted entries.
* Refactor the http handlers to work with soft-deleted entries.
* Implement the worker pool for the deletion requests.