### PR TITLE
Sprint 9: HTTPS, config files, system interruptions

### DIFF
--- a/cmd/shortener/server.go
+++ b/cmd/shortener/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"flag"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,9 +22,7 @@ var (
 
 func main() {
 	printCompilationInfo()
-
-	cfg := config.New(config.WithEnv(), config.WithFlags())
-	flag.Parse()
+	cfg := config.New(config.WithEnv(), config.WithFlags(), config.WithFile())
 
 	repo, err := getRepo(context.Background(), cfg)
 	if err != nil {

--- a/cmd/shortener/server.go
+++ b/cmd/shortener/server.go
@@ -40,12 +40,6 @@ func main() {
 
 	r := handlers.NewShortenerRouter(cfg, repo)
 	serv := getServer(cfg, r)
-	defer func(serv *http.Server) {
-		if sErr := serv.Close(); sErr != nil {
-			log.Error(sErr)
-		}
-	}(serv)
-
 	if cfg.IsSecure() {
 		if err = serv.ListenAndServeTLS("tls.crt", "tls.key"); err != nil {
 			log.Error(err)
@@ -75,7 +69,6 @@ func getServer(cfg *config.Config, handler http.Handler) *http.Server {
 	}
 
 	if cfg.IsSecure() {
-		log.Info("secure")
 		s.TLSConfig = getTLSConfig()
 	}
 
@@ -102,9 +95,6 @@ func getTLSConfig() *tls.Config {
 		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 		},
 	}
 }

--- a/cmd/shortener/server.go
+++ b/cmd/shortener/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
@@ -38,27 +39,47 @@ func main() {
 	}(repo)
 
 	r := handlers.NewShortenerRouter(cfg, repo)
-	if err = getServer(cfg.Addr, r).ListenAndServe(); err != nil {
-		log.Error(err)
+	serv := getServer(cfg, r)
+	defer func(serv *http.Server) {
+		if sErr := serv.Close(); sErr != nil {
+			log.Error(sErr)
+		}
+	}(serv)
+
+	if cfg.IsSecure() {
+		if err = serv.ListenAndServeTLS("tls.crt", "tls.key"); err != nil {
+			log.Error(err)
+		}
+	} else {
+		if err = serv.ListenAndServe(); err != nil {
+			log.Error(err)
+		}
 	}
 }
 
 func getRepo(ctx context.Context, cfg *config.Config) (storage.Storager, error) {
-	if cfg.DBURL != "" {
-		return storage.NewDBRepo(ctx, cfg.DBURL)
+	if cfg.GetDBURL() != "" {
+		return storage.NewDBRepo(ctx, cfg.GetDBURL())
 	}
-	if cfg.Filename != "" {
-		return storage.NewFileRepo(cfg.Filename)
+	if cfg.GetStorageFileName() != "" {
+		return storage.NewFileRepo(cfg.GetStorageFileName())
 	}
 	return storage.NewMemoryRepo(), nil
 }
 
-func getServer(addr string, handler http.Handler) *http.Server {
-	return &http.Server{
-		Addr:              addr,
+func getServer(cfg *config.Config, handler http.Handler) *http.Server {
+	s := &http.Server{
+		Addr:              cfg.GetServerAddr(),
 		Handler:           handler,
 		ReadHeaderTimeout: 3 * time.Second,
 	}
+
+	if cfg.IsSecure() {
+		log.Info("secure")
+		s.TLSConfig = getTLSConfig()
+	}
+
+	return s
 }
 
 func printCompilationInfo() {
@@ -73,4 +94,17 @@ func getCompilationInfoValue(v string) string {
 		return v
 	}
 	return "N/A"
+}
+
+func getTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion:       tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}
 }

--- a/internal/apperrors/errors.go
+++ b/internal/apperrors/errors.go
@@ -22,6 +22,7 @@ const (
 	FilenameMissing  = "the filename is missing"
 	FileMalformed    = "the file is malformed"
 	RepoEntryInvalid = "the stored entry is invalid"
+	EmptyDBURL       = "the provided DB URL is empty"
 )
 
 // AppError describes a custom error.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,11 +4,12 @@ package config
 import (
 	"encoding/json"
 	"flag"
-	"github.com/caarlos0/env"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"reflect"
+
+	"github.com/caarlos0/env"
+	log "github.com/sirupsen/logrus"
 )
 
 // Config describes the configuration required across the application.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,12 @@ import (
 // Config describes the configuration required across the application.
 // Since the configuration can be initiated via the environment flags, the struct contains the required annotation.
 type Config struct {
-	Addr           string `env:"SERVER_ADDRESS" envDefault:"localhost:8080"`
-	BaseURL        string `env:"BASE_URL" envDefault:"http://localhost:8080"`
-	DBURL          string `env:"DATABASE_DSN"`
-	Filename       string `env:"FILE_STORAGE_PATH"`
+	Addr           string
+	BaseURL        string
+	DBURL          string
+	Filename       string
 	PoolSize       int
+	Secure         bool
 	UserCookieName string
 }
 
@@ -45,6 +46,7 @@ func WithFlags() func(*Config) {
 		flag.StringVar(&cfg.Addr, "a", cfg.Addr, "The application server address")
 		flag.StringVar(&cfg.BaseURL, "b", cfg.BaseURL, "The application server port")
 		flag.StringVar(&cfg.DBURL, "d", cfg.DBURL, "The DB connection URL")
+		flag.BoolVar(&cfg.Secure, "s", cfg.Secure, "The HTTPS connection config")
 		flag.StringVar(&cfg.Filename, "f", cfg.Filename, "The file storage name")
 	}
 }
@@ -55,6 +57,10 @@ func (c *Config) GetBaseURL() string {
 
 func (c *Config) GetDBURL() string {
 	return c.DBURL
+}
+
+func (c *Config) IsSecure() bool {
+	return c.Secure
 }
 
 func (c *Config) GetPoolSize() int {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,12 @@ import (
 // Config describes the configuration required across the application.
 // Since the configuration can be initiated via the environment flags, the struct contains the required annotation.
 type Config struct {
-	Addr           string
-	BaseURL        string
-	DBURL          string
-	Filename       string
+	Addr           string `env:"SERVER_ADDRESS" envDefault:"localhost:8080"`
+	BaseURL        string `env:"BASE_URL" envDefault:"http://localhost:8080"`
+	DBURL          string `env:"DATABASE_DSN"`
+	Filename       string `env:"FILE_STORAGE_PATH"`
 	PoolSize       int
-	Secure         bool
+	Secure         bool `env:"ENABLE_HTTPS"`
 	UserCookieName string
 }
 
@@ -29,6 +29,8 @@ func New(opts ...func(*Config)) *Config {
 	for _, o := range opts {
 		o(cfg)
 	}
+
+	log.Info(cfg)
 
 	return cfg
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,21 +20,19 @@ type Config struct {
 	ConfigFile     string `env:"CONFIG"`
 	DBURL          string `json:"database_dsn" env:"DATABASE_DSN"`
 	Filename       string `json:"file_storage_path" env:"FILE_STORAGE_PATH"`
-	PoolSize       int
-	Secure         bool `json:"enable_https" env:"ENABLE_HTTPS"`
-	UserCookieName string
+	PoolSize       int    `json:"pool_size" env:"POOL_SIZE" envDefault:"10"`
+	Secure         bool   `json:"enable_https" env:"ENABLE_HTTPS"`
+	UserCookieName string `json:"user_cookie" env:"USER_COOKIE" envDefault:"user_id"`
 }
 
 func New(opts ...func(*Config)) *Config {
 	cfg := &Config{
-		UserCookieName: "user_id",
 		PoolSize:       10,
+		UserCookieName: "user_id",
 	}
-
 	for _, o := range opts {
 		o(cfg)
 	}
-
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,22 +2,34 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
-
 	"github.com/caarlos0/env"
 	log "github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"reflect"
 )
 
 // Config describes the configuration required across the application.
 // Since the configuration can be initiated via the environment flags, the struct contains the required annotation.
 type Config struct {
-	Addr           string `env:"SERVER_ADDRESS" envDefault:"localhost:8080"`
-	BaseURL        string `env:"BASE_URL" envDefault:"http://localhost:8080"`
-	DBURL          string `env:"DATABASE_DSN"`
-	Filename       string `env:"FILE_STORAGE_PATH"`
+	Addr           string `json:"server_address" env:"SERVER_ADDRESS" envDefault:"localhost:8080"`
+	BaseURL        string `json:"base_url" env:"BASE_URL" envDefault:"http://localhost:8080"`
+	ConfigFile     string `env:"CONFIG"`
+	DBURL          string `json:"database_dsn" env:"DATABASE_DSN"`
+	Filename       string `json:"file_storage_path" env:"FILE_STORAGE_PATH"`
 	PoolSize       int
-	Secure         bool `env:"ENABLE_HTTPS"`
+	Secure         bool `json:"enable_https" env:"ENABLE_HTTPS"`
 	UserCookieName string
+}
+
+var cfgToFileMap = map[string]string{
+	"Addr":     "server_address",
+	"BaseURL":  "base_url",
+	"DBURL":    "database_dsn",
+	"Filename": "file_storage_path",
+	"Secure":   "enable_https",
 }
 
 func New(opts ...func(*Config)) *Config {
@@ -29,8 +41,6 @@ func New(opts ...func(*Config)) *Config {
 	for _, o := range opts {
 		o(cfg)
 	}
-
-	log.Info(cfg)
 
 	return cfg
 }
@@ -47,10 +57,63 @@ func WithFlags() func(*Config) {
 	return func(cfg *Config) {
 		flag.StringVar(&cfg.Addr, "a", cfg.Addr, "The application server address")
 		flag.StringVar(&cfg.BaseURL, "b", cfg.BaseURL, "The application server port")
+		flag.StringVar(&cfg.ConfigFile, "c", cfg.ConfigFile, "The application configuration file")
+		flag.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "The application configuration file")
 		flag.StringVar(&cfg.DBURL, "d", cfg.DBURL, "The DB connection URL")
 		flag.BoolVar(&cfg.Secure, "s", cfg.Secure, "The HTTPS connection config")
 		flag.StringVar(&cfg.Filename, "f", cfg.Filename, "The file storage name")
+		flag.Parse()
 	}
+}
+
+func WithFile() func(*Config) {
+	return func(cfg *Config) {
+		if cfg.ConfigFile == "" {
+			return
+		}
+		fCfg, err := getConfigFromFile(cfg.ConfigFile)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		rCfg := reflect.Indirect(reflect.ValueOf(cfg))
+		for i := 0; i < rCfg.NumField(); i++ {
+			rField := rCfg.Type().Field(i).Name
+			rValue := rCfg.FieldByName(rField)
+
+			if fileField, ok := cfgToFileMap[rField]; ok && rValue.CanSet() && rValue.IsZero() {
+				if fileValue, ok := fCfg[fileField]; ok {
+					rValue.Set(reflect.ValueOf(fileValue))
+				}
+			}
+		}
+
+		log.Info(cfg)
+	}
+}
+
+func getConfigFromFile(filepath string) (map[string]interface{}, error) {
+	var cfg map[string]interface{}
+
+	file, err := os.OpenFile(filepath, os.O_RDONLY|os.O_CREATE, 0o777)
+	if err != nil {
+		return cfg, err
+	}
+
+	defer func(file *os.File) {
+		if fErr := file.Close(); fErr != nil {
+			log.Error(err)
+		}
+	}(file)
+
+	rawCfg, err := io.ReadAll(file)
+	if err != nil {
+		return cfg, err
+	}
+
+	err = json.Unmarshal(rawCfg, &cfg)
+	return cfg, err
 }
 
 func (c *Config) GetBaseURL() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +73,65 @@ func TestWithFlags(t *testing.T) {
 	}
 }
 
+func TestWithFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		fileCfg  Config
+		want     *Config
+	}{
+		{
+			name: "Default config",
+			want: &Config{
+				PoolSize:       10,
+				UserCookieName: "user_id",
+			},
+		},
+		{
+			name:     "File config",
+			filename: "test_cfg.json",
+			fileCfg:  Config{Secure: true},
+			want: &Config{
+				Addr:           "localhost:8080",
+				BaseURL:        "http://localhost:8080",
+				ConfigFile:     "test_cfg.json",
+				PoolSize:       10,
+				Secure:         true,
+				UserCookieName: "user_id",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *Config
+
+			if tt.filename != "" {
+				if err := setupFileConfig(tt.filename, tt.fileCfg); err != nil {
+					t.Fatal(err)
+				}
+				got = New(WithEnv(), WithFile())
+			} else {
+				got = New(WithFile())
+			}
+
+			assert.Equal(t, tt.want.Addr, got.Addr)
+			assert.Equal(t, tt.want.BaseURL, got.BaseURL)
+			assert.Equal(t, tt.want.ConfigFile, got.ConfigFile)
+			assert.Equal(t, tt.want.DBURL, got.DBURL)
+			assert.Equal(t, tt.want.Filename, got.Filename)
+			assert.Equal(t, tt.want.PoolSize, got.PoolSize)
+			assert.Equal(t, tt.want.Secure, got.Secure)
+			assert.Equal(t, tt.want.UserCookieName, got.UserCookieName)
+
+			if tt.filename != "" {
+				if err := cleanFileConfig(tt.filename); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestConfig_GetBaseURL(t *testing.T) {
 	cfg := New(WithEnv())
 	assert.Equal(t, "http://localhost:8080", cfg.GetBaseURL())
@@ -99,4 +160,30 @@ func TestConfig_GetPoolSize(t *testing.T) {
 func TestConfig_GetUserCookieName(t *testing.T) {
 	cfg := New(WithEnv())
 	assert.Equal(t, "user_id", cfg.GetUserCookieName())
+}
+
+func TestConfig_IsSecure(t *testing.T) {
+	cfg := New(WithEnv())
+	assert.Equal(t, false, cfg.IsSecure())
+}
+
+func setupFileConfig(filename string, cfg Config) error {
+	if err := os.Setenv("CONFIG", filename); err != nil {
+		return err
+	}
+
+	var f *os.File
+	var err error
+	f, err = os.Create(filename)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(f).Encode(cfg)
+}
+
+func cleanFileConfig(filename string) error {
+	if err := os.Unsetenv("CONFIG"); err != nil {
+		return err
+	}
+	return os.Remove(filename)
 }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -36,7 +36,7 @@ type DBRepo struct {
 // If the DB didn't connect, or the DB table creation has failed, the error will be returned.
 func NewDBRepo(ctx context.Context, url string) (DBRepo, error) {
 	db, err := sql.Open("pgx", url)
-	if err != nil {
+	if err != nil || url == "" {
 		return DBRepo{}, err
 	}
 

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"go-url-shortener/internal/apperrors"
 
 	_ "github.com/jackc/pgx/v4/stdlib" // SQL driver
 	"github.com/lib/pq"
@@ -35,8 +36,12 @@ type DBRepo struct {
 // NewDBRepo returns a new instance of the DBRepo type.
 // If the DB didn't connect, or the DB table creation has failed, the error will be returned.
 func NewDBRepo(ctx context.Context, url string) (DBRepo, error) {
+	if url == "" {
+		return DBRepo{}, errors.New(apperrors.EmptyDBURL)
+	}
+
 	db, err := sql.Open("pgx", url)
-	if err != nil || url == "" {
+	if err != nil {
 		return DBRepo{}, err
 	}
 

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewDBRepo(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    DBRepo
+		wantErr bool
+	}{
+		{
+			name: "Missing URL",
+		},
+		{
+			name:    "Incorrect URL",
+			url:     "test",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewDBRepo(context.Background(), tt.url)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantErr, err != nil)
+		})
+	}
+}
+
 func TestDBRepo_Add(t *testing.T) {
 	for _, tt := range getAddTestCases() {
 		t.Run(tt.name, func(t *testing.T) {
@@ -212,8 +238,24 @@ func TestDBRepo_Has(t *testing.T) {
 	}
 }
 
+func TestDBRepo_Ping(t *testing.T) {
+	t.Run("ping", func(t *testing.T) {
+		db, mock := getMock(t)
+		defer func(db *sql.DB) {
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}(db)
+		r := DBRepo{db: db}
+
+		mock.ExpectPing()
+		mock.ExpectClose()
+		assert.True(t, r.Ping(context.Background()))
+	})
+}
+
 func getMock(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
-	db, mock, err := sqlmock.New()
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -19,7 +19,8 @@ func TestNewDBRepo(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Missing URL",
+			name:    "Missing URL",
+			wantErr: true,
 		},
 		{
 			name:    "Incorrect URL",


### PR DESCRIPTION
**Changes:**
* Add environment variable and flag describing the HTTPS connection requirement.
* Expand the server initialization with TLS configs.
* Add a possibility to set the config file name via an environment variable and a flag.
* Implement the update of the config's zero-valued fields via reflection.
* Implement server graceful shutdown based on the pending requests and timeout.
* Improve unit-tests coverage.

**Incremental changes:**
* [Increment 20: HTTPS config](https://github.com/agodlevskii/go-url-shortener/pull/26)
* [Increment 21: File config](https://github.com/agodlevskii/go-url-shortener/pull/27)
* [Increment 22: Server graceful shutdown](https://github.com/agodlevskii/go-url-shortener/pull/28)